### PR TITLE
Expose ModuleMetadata type

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -101,6 +101,7 @@ pub use crate::{
     metadata::{
         Metadata,
         MetadataError,
+        ModuleMetadata,
     },
     rpc::{
         BlockNumber,


### PR DESCRIPTION
This is actually already done in master on the core subxt library (ModuleMetadata has been renamed to PalletMetadata there).